### PR TITLE
Replace hardcoded integer-parse with a sanity check on tag components

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -80,12 +80,18 @@ function computeVersion(tag: string, offset: number): string {
         console.log(`Found classifier to append: ${split[1]}`)
     }
 
-    const parts = tag.split(".").map(e => parseInt(e));
+    const parts = tag.split(".")     // Get parts of the tag so we can verify it fits the correct format.
+    for (const part in parts) {      // Verify that all parts of the tag pass verification, just for internal consistency
+                // Regex: One integer, then zero or more of any other character.
+        if ( !( /^\d.*$/.test(part) ) )  // JPMS requires that versions begin with a number.
+         console.log(`Invalid tag component: ${part} must begin with a numeric digit.`)
+    }
+    
     console.log(`Found version parts: ${parts.join(", ")}`)
     if (parts.length < 3) {
-        parts.push(offset)
+        parts.push(offset.toString())
     } else {
-        parts[parts.length - 1] += offset
+        parts[parts.length - 1] = (parseInt(parts[parts.length - 1]) + offset).toString()
     }
 
     return parts.join(".") + toAppend


### PR DESCRIPTION
Currently, the usage of `const parts = tag.split(".").map(e => parseInt(e));` means that non-integer characters are stripped from tags when used for building in Actions.

This means that tags like `0.25w14craftmine` get reduced to `0.25`.

Instead of mapping all components to integer, I test all components against a simple regex:

```
/^\d.*$/
  |  |
  |  |
  |  L Match zero or more character of any kind
  |
  L Match Exactly one numeric digit
```

This verifies that the tag represents a valid JPMS module version/name, and that it matches our internal standards for tag specificity and versioning principles.